### PR TITLE
fix: Decoupled Header component

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { use } from "react";
 
-import { DataContext } from "../../../context/DataContext";
+import { DataContext } from "../../context/DataContext";
 
 export const Header = () => {
   const context = use(DataContext);

--- a/src/components/KanbanView/KanbanView.tsx
+++ b/src/components/KanbanView/KanbanView.tsx
@@ -1,12 +1,10 @@
-import { Header } from "../TableView/Header/Header";
-import { Search } from "../TableView/Search/Search";
+import { Header } from "../Header/Header";
 import { KanbanTable } from "./KanbanTable/KanbanTable";
 
 export const KanbanView = () => {
   return (
     <div className="w-full">
       <Header />
-      <Search />
       <KanbanTable />
     </div>
   );

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -1,4 +1,4 @@
-import { Header } from "./Header/Header";
+import { Header } from "../Header/Header";
 import { Actions } from "./Actions/Actions";
 import { Search } from "./Search/Search";
 import { TasksTable } from "./TasksTable/TasksTable";


### PR DESCRIPTION
Header component was initially located inside TableView. Placed it in a higher directory to be used more generally.

Also removed the Search component from Kanban view.