### PR TITLE
feat: edit tasks in kanban view

### DIFF
--- a/src/components/KanbanView/Card/Card.tsx
+++ b/src/components/KanbanView/Card/Card.tsx
@@ -7,10 +7,12 @@ interface ICard {
   key: number;
   task: ITask | { id: number; title: string; status: string; priority: string };
   cardType: "card" | "overlay";
+  openEditTaskModal?: () => void;
+  setTaskToEdit?: React.Dispatch<React.SetStateAction<ITask | null>>;
 }
 
 export const Card = (props: ICard) => {
-  const { task, cardType } = props;
+  const { task, cardType, openEditTaskModal, setTaskToEdit } = props;
 
   const {
     attributes,
@@ -24,6 +26,30 @@ export const Card = (props: ICard) => {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+  };
+
+  // Checks if the given task is an ITask
+  function isITask(
+    task: { id: number; title: string; status: string; priority: string } | null
+  ): task is ITask {
+    return (
+      task != null &&
+      typeof task.id === "number" &&
+      typeof task.title === "string" &&
+      ["Not Started", "In Progress", "Completed"].includes(task.status) &&
+      typeof task.priority === "string"
+    );
+  }
+
+  // Confirms opening the edit task modal.
+  // Checks if the openEditTaskModal and setTaskToEdit functions exist and if the task is an ITask.
+  const confirmOpenEditTaskModal = () => {
+    if (!openEditTaskModal || !setTaskToEdit || !isITask(task)) {
+      return;
+    }
+
+    setTaskToEdit(task);
+    openEditTaskModal();
   };
 
   const cardStyles = `${
@@ -40,6 +66,7 @@ export const Card = (props: ICard) => {
       {...attributes}
       {...listeners}
       className={`${cardType === "card" ? cardStyles : overlayStyles}`}
+      onClick={confirmOpenEditTaskModal}
     >
       <div>
         <div className="text-xl font-bold">{task.title}</div>

--- a/src/components/KanbanView/KanbanColumn/KanbanColumn.tsx
+++ b/src/components/KanbanView/KanbanColumn/KanbanColumn.tsx
@@ -1,6 +1,7 @@
 import { useState, use } from "react";
 
 import AddTaskModal from "../../../UI/FormModals/AddTaskModal";
+import EditTaskModal from "../../../UI/FormModals/EditTaskModal";
 
 import { DataContext } from "../../../context/DataContext";
 
@@ -23,7 +24,9 @@ interface IKanbanColumn {
 
 export const KanbanColumn = ({ title, tasks }: IKanbanColumn) => {
   const [addTaskModalOpen, setAddTaskModalOpen] = useState<boolean>(false);
+  const [editTaskModalOpen, setEditTaskModalOpen] = useState<boolean>(false);
   const [columnToAddTask, setColumnToAddTask] = useState<string>("");
+  const [taskToEdit, setTaskToEdit] = useState<ITask | null>(null);
 
   // Title for Add Task modal.
   const AddTaskTitle = "Add Task";
@@ -45,6 +48,25 @@ export const KanbanColumn = ({ title, tasks }: IKanbanColumn) => {
     addTask(newTask);
   };
 
+  // Title for Edit Task modal.
+  const EditTaskTitle = "Edit Task";
+
+  // Opens Edit Task Modal
+  const openEditTaskModal = () => {
+    setEditTaskModalOpen(true);
+  };
+
+  // Closes Edit Task Modal
+  const closeEditTaskModal = () => {
+    setEditTaskModalOpen(false);
+    setTaskToEdit(null);
+  };
+
+  // Confirms editing a task
+  const confirmEditTask = (editedTask: ITask) => {
+    editTask(editedTask);
+  };
+
   const { setNodeRef } = useDroppable({ id: title });
 
   const tasksToRender = tasks ? tasks : [];
@@ -57,7 +79,7 @@ export const KanbanColumn = ({ title, tasks }: IKanbanColumn) => {
   }
 
   // Using context
-  const { addTask } = context;
+  const { addTask, editTask } = context;
 
   return (
     <SortableContext
@@ -73,14 +95,30 @@ export const KanbanColumn = ({ title, tasks }: IKanbanColumn) => {
           columnToAddTask={columnToAddTask}
         />
       ) : null}
+      {editTaskModalOpen && taskToEdit ? (
+        <EditTaskModal
+          title={EditTaskTitle}
+          confirmAction={confirmEditTask}
+          cancelAction={closeEditTaskModal}
+          task={taskToEdit}
+        />
+      ) : null}
       <div
         ref={setNodeRef}
-        className="flex flex-col justify-start items-center gap-2 w-[500px] my-4 px-4 py-2 min-h-[200px] bg-gray-300 rounded-2xl"
+        className="flex flex-col justify-start items-center gap-2 w-[70vw] md:w-[500px] my-4 px-4 py-2 min-h-[200px] bg-gray-300 rounded-2xl"
       >
         <div className=" w-full text-left font-bold">{title}</div>
         {tasksToRender.map((task) => {
           if (!task) return;
-          return <Card key={task.id} task={task} cardType="card" />;
+          return (
+            <Card
+              key={task.id}
+              task={task}
+              cardType="card"
+              openEditTaskModal={openEditTaskModal}
+              setTaskToEdit={setTaskToEdit}
+            />
+          );
         })}
 
         <AddTaskCard

--- a/src/components/KanbanView/KanbanTable/KanbanTable.tsx
+++ b/src/components/KanbanView/KanbanTable/KanbanTable.tsx
@@ -38,7 +38,11 @@ export const KanbanTable = () => {
 
   // Sensors for dndkit
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
     useSensor(TouchSensor),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,

--- a/src/components/TableView/TasksTable/components/TaskCard.tsx
+++ b/src/components/TableView/TasksTable/components/TaskCard.tsx
@@ -42,17 +42,17 @@ export const TaskCard = ({ task }: ITaskCard) => {
   // Title for Edit Task modal.
   const EditTaskTitle = "Edit Task";
 
-  // Opens Add Task Modal
+  // Opens Edit Task Modal
   const openEditTaskModal = () => {
     setEditTaskModalOpen(true);
   };
 
-  // Closes Add Task Modal
+  // Closes Edit Task Modal
   const closeEditTaskModal = () => {
     setEditTaskModalOpen(false);
   };
 
-  // Confirms adding task
+  // Confirms editing a task
   const confirmEditTask = (editedTask: ITask) => {
     editTask(editedTask);
   };
@@ -62,17 +62,17 @@ export const TaskCard = ({ task }: ITaskCard) => {
   const DeleteTaskDescription =
     "Are you sure you want to PERMANENTELY delete this task? ";
 
-  // Opens Add Task Modal
+  // Opens Delete Task Modal
   const openDeleteTaskModal = () => {
     setDeleteTaskModalOpen(true);
   };
 
-  // Closes Add Task Modal
+  // Closes Delete Task Modal
   const closeDeleteTaskModal = () => {
     setDeleteTaskModalOpen(false);
   };
 
-  // Confirms adding task
+  // Confirms deleting a task
   const confirmDeleteTask = (deletedTask: ITask) => {
     deleteTask(deletedTask);
   };


### PR DESCRIPTION
Users can now open an edit task modal in kanban view by clicking a task card. Uses the existing EditTaskModal component.

Did some style changes to column width to make them smaller on mobile. This fixes the problem of the task cards taking up the entire width on mobile and preventing users from scrolling.

Adjusted dndkit's sensors so that it's activation constraint happens when the drag distance is greater than 5 pixels. This means that clicks can be registered without activating the drag feature.

